### PR TITLE
Add explicit types for children

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,8 @@ declare module "react-multi-clamp" {
     onClampEnd?: (result: { didClamp: boolean }) => void;
 
     ref?: React.Ref<MultiClampHTMLDivElement | undefined>;
+    
+    children?: React.ReactNode;
   };
 
   const Clamp: React.FC<ClampProps>;


### PR DESCRIPTION
Explicit `children` prop is required for compatibility with `@types/react@^18.0.0`

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210